### PR TITLE
Fix DataStore errors on private servers

### DIFF
--- a/DataStore/DataStore_Achievements/DataStore_Achievements.lua
+++ b/DataStore/DataStore_Achievements/DataStore_Achievements.lua
@@ -55,9 +55,9 @@ local function ScanSingleAchievement(id, isCompleted, month, day, year)
 	   if critCompleted then 
 	      table.insert(CriteriaCache, tostring(j))
 	   else                  
-	      if reqQuantity > 1 then
-	         table.insert(CriteriaCache, j .. ":" .. quantity)
-	      end
+               if reqQuantity and reqQuantity > 1 then
+                       table.insert(CriteriaCache, j .. ":" .. quantity)
+               end
 	   end
 	end
 	

--- a/DataStore/DataStore_Characters/DataStore_Characters.lua
+++ b/DataStore/DataStore_Characters/DataStore_Characters.lua
@@ -127,25 +127,28 @@ local function _GetCharacterClass(character)
 end
 
 local ClassColors = {
-	["MAGE"] = "|cFF69CCF0",
-	["WARRIOR"] = "|cFFC79C6E",
-	["HUNTER"] = "|cFFABD473",
-	["ROGUE"] = "|cFFFFF569",
-	["WARLOCK"] = "|cFF9482CA", 
-	["DRUID"] = "|cFFFF7D0A", 
-	["SHAMAN"] = "|cFF2459FF",
-	["PALADIN"] = "|cFFF58CBA", 
-	["PRIEST"] = "|cFFFFFFFF",
-	["DEATHKNIGHT"] = "|cFFC41F3B"
+       ["MAGE"] = "|cFF69CCF0",
+       ["WARRIOR"] = "|cFFC79C6E",
+       ["HUNTER"] = "|cFFABD473",
+       ["ROGUE"] = "|cFFFFF569",
+       ["WARLOCK"] = "|cFF9482CA",
+       ["DRUID"] = "|cFFFF7D0A",
+       ["SHAMAN"] = "|cFF2459FF",
+       ["PALADIN"] = "|cFFF58CBA",
+       ["PRIEST"] = "|cFFFFFFFF",
+       ["DEATHKNIGHT"] = "|cFFC41F3B"
 }
 
+local DEFAULT_CLASS_COLOR = "|cFFFFFFFF"
+
 local function _GetColoredCharacterName(character)
-	return ClassColors[character.englishClass] .. character.name
+       local color = ClassColors[character.englishClass] or DEFAULT_CLASS_COLOR
+       return color .. character.name
 end
-	
+
 local function _GetClassColor(character)
-	-- return just the color of this character's class
-	return ClassColors[character.englishClass]
+       -- return just the color of this character's class
+       return ClassColors[character.englishClass] or DEFAULT_CLASS_COLOR
 end
 
 local function _GetCharacterFaction(character)


### PR DESCRIPTION
## Summary
- avoid nil errors when using unknown classes in DataStore_Characters
- handle achievements criteria without required quantity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68475c4bbb54832f9f6e9f74ec399cc6