### PR TITLE
Integrate GuildQuickInvite with WIM

### DIFF
--- a/WIM/Localization/deDE.lua
+++ b/WIM/Localization/deDE.lua
@@ -222,6 +222,8 @@ WIM.AddLocale("deDE", {
     ["Invite to Party"] = "In die Gruppe einladen",
     ["Add Friend"] = "Freund hinzuf\195\188gen",
     ["Ignore User"] = "Spieler ignorieren",
+    ["Invite to Guild"] = "In die Gilde einladen",
+    ["Recruit"] = "Anwerben",
     ["Are you sure you want to\nignore %s?"] = "Bist du sicher, dass du \n %s ignorieren willst?",
     
     -- Tutorials.lua --

--- a/WIM/Localization/enUS.lua
+++ b/WIM/Localization/enUS.lua
@@ -214,6 +214,8 @@ WIM.AddLocale("enUS", {
     ["Invite to Party"] = true,
     ["Add Friend"] = true,
     ["Ignore User"] = true,
+    ["Invite to Guild"] = true,
+    ["Recruit"] = true,
     ["Are you sure you want to\nignore %s?"] = true,
     ["Right-Click for profile links..."] = true,
     ["Profile Links"] = true,

--- a/WIM/Localization/frFR.lua
+++ b/WIM/Localization/frFR.lua
@@ -213,6 +213,8 @@ WIM.AddLocale("frFR", {
     ["Invite to Party"] = "Inviter pour groupage",
     ["Add Friend"] = "Ajouter un ami",
     ["Ignore User"] = "Ignorer cet utilisateur",
+    ["Invite to Guild"] = "Inviter dans la guilde",
+    ["Recruit"] = "Recruter",
     ["Are you sure you want to\nignore %s?"] = "Êtes-vous sûr de vouloir ignorer %s?",
     ["Right-Click for profile links..."] = "Clic droit pour link le Profil...",
     ["Profile Links"] = "Liens du profil",

--- a/WIM/Localization/koKR.lua
+++ b/WIM/Localization/koKR.lua
@@ -212,6 +212,8 @@ WIM.AddLocale("koKR", {
     ["Invite to Party"] = "파티 초대",
     ["Add Friend"] = "친구 추가",
     ["Ignore User"] = "차단 설정",
+    ["Invite to Guild"] = "길드 초대",
+    ["Recruit"] = "모집", 
     ["Are you sure you want to\nignore %s?"] = "당신은 %s 의 차단을 원합니까?",
     
     -- Tutorials.lua --

--- a/WIM/Localization/ruRU.lua
+++ b/WIM/Localization/ruRU.lua
@@ -213,8 +213,10 @@ WIM.AddLocale("ruRU", {
 	["Coordinates"] = "Координаты персонажа",
 	["Invite to Party"] = "Пригласить в группу",
 	["Add Friend"] = "Добавить в друзья",
-	["Ignore User"] = "Игнорировать персонажа",
-	["Are you sure you want to\nignore %s?"] = "Вы уверены что вы хотите добавить\nперсонажа %s в черный список?",
+        ["Ignore User"] = "Игнорировать персонажа",
+        ["Invite to Guild"] = "Пригласить в гильдию",
+        ["Recruit"] = "Рекрут", 
+        ["Are you sure you want to\nignore %s?"] = "Вы уверены что вы хотите добавить\nперсонажа %s в черный список?",
     ["Right-Click for profile links..."] = "[Правый-Клик] - ссылка на профиль...",
     ["Profile Links"] = "Ссылка на профиль",
     

--- a/WIM/Localization/zhCN.lua
+++ b/WIM/Localization/zhCN.lua
@@ -216,6 +216,8 @@ WIM.AddLocale("zhCN", {
     ["Invite to Party"] = "组队邀请",
     ["Add Friend"] = "加入好友",
     ["Ignore User"] = "加入黑名单",
+    ["Invite to Guild"] = "公会邀请",
+    ["Recruit"] = "招募",
     ["Are you sure you want to\nignore %s?"] = "您确定您要忽略 %s",
     
     -- Tutorials.lua --

--- a/WIM/Localization/zhTW.lua
+++ b/WIM/Localization/zhTW.lua
@@ -217,6 +217,8 @@ WIM.AddLocale("zhTW", {
     ["Invite to Party"] = "組隊邀請",
     ["Add Friend"] = "加入好友",
     ["Ignore User"] = "加入黑名單",
+    ["Invite to Guild"] = "公會邀請",
+    ["Recruit"] = "招募",
     ["Are you sure you want to\nignore %s?"] = "您確定您要忽略 %s",
     ["Right-Click for profile links..."] ="右鍵點擊 查看英雄榜",
     ["Profile Links"] = "查看英雄榜",

--- a/WIM/Modules/ShortcutBar.lua
+++ b/WIM/Modules/ShortcutBar.lua
@@ -223,14 +223,15 @@ end
 function ShortcutBar:OnWindowShow(obj)
     if(obj.widgets.shortcuts) then
         for i=1, #buttons do
-        if(buttons[i].id == "invite" or buttons[i].id == "ignore") then
-            if(obj.isBN and obj.bn.realmName ~= env.realm) then
-                obj.widgets.shortcuts.buttons[i]:Disable();
-            else
-                obj.widgets.shortcuts.buttons[i]:Enable();
+            if(buttons[i].id == "invite" or buttons[i].id == "ignore" or
+               buttons[i].id == "gqiinvite" or buttons[i].id == "gqirecruit") then
+                if(obj.isBN and obj.bn.realmName ~= env.realm) then
+                    obj.widgets.shortcuts.buttons[i]:Disable();
+                else
+                    obj.widgets.shortcuts.buttons[i]:Enable();
+                end
             end
         end
-    end
         obj.widgets.shortcuts:UpdateButtons();
     end
 end

--- a/WIM/Skins/Default/skin.lua
+++ b/WIM/Skins/Default/skin.lua
@@ -228,6 +228,8 @@ local WIM_ClassicSkin = {
                         invite = "Interface\\Icons\\Spell_Holy_BlessingOfStrength",
                         friend = "Interface\\Icons\\INV_Misc_GroupNeedMore",
                         ignore = "Interface\\Icons\\Ability_Physical_Taunt",
+                        gqiinvite = "Interface\\Icons\\INV_Misc_TabardPVP_01",
+                        gqirecruit = "Interface\\Icons\\INV_Misc_Note_02",
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add guild invite and recruit buttons to WIM's shortcut bar
- register buttons from GuildQuickInvite when WIM loads
- support cross realm disable for new buttons
- provide guild related icons for the new shortcuts
- localize "Invite to Guild" and "Recruit" strings in all locales

## Testing
- `luac -p GuildQuickInvite/GuildQuickInvite.lua`
- `luac -p WIM/Modules/ShortcutBar.lua`
- `luac -p WIM/Skins/Default/skin.lua`
- `luac -p WIM/Localization/enUS.lua`
- `luac -p WIM/Localization/deDE.lua`
- `luac -p WIM/Localization/frFR.lua`
- `luac -p WIM/Localization/koKR.lua`
- `luac -p WIM/Localization/ruRU.lua`
- `luac -p WIM/Localization/zhCN.lua` *(fails: unexpected symbol near '')*
- `luac -p WIM/Localization/zhTW.lua` *(fails: unexpected symbol near '')*


------
https://chatgpt.com/codex/tasks/task_e_684760ba6398832fba0cb689ad512396