### PR TITLE
Fix MoveAnything skin error

### DIFF
--- a/ElvUI/ElvUI_AddOnSkins/Skins/Addons/moveAnything.lua
+++ b/ElvUI/ElvUI_AddOnSkins/Skins/Addons/moveAnything.lua
@@ -25,12 +25,16 @@ S:AddCallbackForAddon("MoveAnything", "MoveAnything", function()
 		_G[self:GetName() .. "BackdropMovingFrameName"]:SetTextColor(unpack(E.media.rgbvaluecolor))
 	end
 
-	for i = 1, 20 do
-		_G["MAMover" .. i .. "Backdrop"]:SetTemplate("Transparent")
-		_G["MAMover" .. i]:HookScript("OnShow", moverOnShow)
-		_G["MAMover" .. i]:SetScript("OnEnter", moverOnEnter)
-		_G["MAMover" .. i]:SetScript("OnLeave", moverOnLeave)
-	end
+       for i = 1, 20 do
+               local mover = _G["MAMover" .. i]
+               local backdrop = _G["MAMover" .. i .. "Backdrop"]
+               if mover and backdrop then
+                       backdrop:SetTemplate("Transparent")
+                       mover:HookScript("OnShow", moverOnShow)
+                       mover:SetScript("OnEnter", moverOnEnter)
+                       mover:SetScript("OnLeave", moverOnLeave)
+               end
+       end
 
 	MAOptions:StripTextures()
 	MAOptions:SetTemplate("Transparent")


### PR DESCRIPTION
## Summary
- guard against missing MoveAnything frames when applying ElvUI AddOn skins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476c9577c8832fb095c1a63f6a9096